### PR TITLE
Properly highlight macro names in definitions

### DIFF
--- a/Erlang.JSON-tmLanguage
+++ b/Erlang.JSON-tmLanguage
@@ -654,13 +654,14 @@
           "name": "meta.directive.define.erlang",
           "patterns": [
             {
-              "begin": "^\\s*(-)\\s*(define)\\s*(\\()\\s*([a-zA-Z_][a-zA-Z\\d@_]*)\\s*(\\()",
+              "begin": "^\\s*(-)\\s*(define)\\s*(\\()\\s*(([a-zA-Z_][a-zA-Z\\d@_]*))\\s*(\\()",
               "beginCaptures": {
                 "1": {"name": "punctuation.section.directive.begin.erlang"},
                 "2": {"name": "keyword.control.directive.preprocessor.define.erlang"},
                 "3": {"name": "punctuation.definition.parameters.begin.erlang"},
-                "4": {"name": "entity.name.macro.definition.erlang"},
-                "5": {"name": "punctuation.definition.parameters.begin.erlang"}
+                "4": {"name": "keyword.other.macro.erlang"},
+                "5": {"name": "entity.name.macro.definition.erlang"},
+                "6": {"name": "punctuation.definition.parameters.begin.erlang"}
               },
               "end": "(\\))\\s*(,)",
               "endCaptures": {

--- a/Erlang.tmLanguage
+++ b/Erlang.tmLanguage
@@ -1853,7 +1853,7 @@
 					<array>
 						<dict>
 							<key>begin</key>
-							<string>^\s*(-)\s*(define)\s*(\()\s*([a-zA-Z_][a-zA-Z\d@_]*)\s*(\()</string>
+							<string>^\s*(-)\s*(define)\s*(\()\s*(([a-zA-Z_][a-zA-Z\d@_]*))\s*(\()</string>
 							<key>beginCaptures</key>
 							<dict>
 								<key>1</key>
@@ -1874,9 +1874,14 @@
 								<key>4</key>
 								<dict>
 									<key>name</key>
-									<string>entity.name.macro.definition.erlang</string>
+									<string>keyword.other.macro.erlang</string>
 								</dict>
 								<key>5</key>
+								<dict>
+									<key>name</key>
+									<string>entity.name.macro.definition.erlang</string>
+								</dict>
+								<key>6</key>
 								<dict>
 									<key>name</key>
 									<string>punctuation.definition.parameters.begin.erlang</string>


### PR DESCRIPTION
Without this commit, macros names are highlighted only if the macro doesn't have any argument.
