### PR TITLE
Highlight comments inside record definitions

### DIFF
--- a/Erlang.JSON-tmLanguage
+++ b/Erlang.JSON-tmLanguage
@@ -1300,7 +1300,8 @@
             },
             {"include": "#comment"}
           ]
-        }
+        },
+        {"include": "#comment"}
       ]
     },
 

--- a/Erlang.tmLanguage
+++ b/Erlang.tmLanguage
@@ -2089,6 +2089,10 @@
 						</dict>
 					</array>
 				</dict>
+				<dict>
+					<key>include</key>
+					<string>#comment</string>
+				</dict>
 			</array>
 		</dict>
 		<key>record-usage</key>


### PR DESCRIPTION
The comment in the first line of the following code wasn't properly highlighted as a comment:

``` erlang
-record(qlc_lc,     % qlc:q/1,2, a query handle
        {lc,
         opt        % #qlc_opt
        }).
```
