### PR TITLE
Line returns in type definitions' aren't handled correctly

### DIFF
--- a/Erlang.JSON-tmLanguage
+++ b/Erlang.JSON-tmLanguage
@@ -119,7 +119,7 @@
           "beginCaptures": {
             "1": {"name": "punctuation.definition.parameters.begin.erlang"}
           },
-          "end": "(\\))\\s*(?=::|\\)?\\s*\\.)",
+          "end": "(\\))",
           "endCaptures": {
             "1": {"name": "punctuation.definition.parameters.end.erlang"}
           },
@@ -129,11 +129,7 @@
               "name": "punctuation.separator.parameters.erlang"
             },
             {"include": "#variable"},
-            {"include": "#comment"},
-            {
-              "match": "[^\\s]",
-              "name": "invalid.illegal.type-parameter.erlang"
-            }
+            {"include": "#comment"}
           ]
         },
         {
@@ -145,6 +141,10 @@
           "patterns": [
             {"include": "#type-expression"}
           ]
+        },
+        {
+          "match": "[^\\s]",
+          "name": "invalid.illegal.type-parameter.erlang"
         }
       ]
     },

--- a/Erlang.tmLanguage
+++ b/Erlang.tmLanguage
@@ -1286,7 +1286,7 @@
 						</dict>
 					</dict>
 					<key>end</key>
-					<string>(\))\s*(?=::|\)?\s*\.)</string>
+					<string>(\))</string>
 					<key>endCaptures</key>
 					<dict>
 						<key>1</key>
@@ -1311,12 +1311,6 @@
 							<key>include</key>
 							<string>#comment</string>
 						</dict>
-						<dict>
-							<key>match</key>
-							<string>[^\s]</string>
-							<key>name</key>
-							<string>invalid.illegal.type-parameter.erlang</string>
-						</dict>
 					</array>
 				</dict>
 				<dict>
@@ -1339,6 +1333,12 @@
 							<string>#type-expression</string>
 						</dict>
 					</array>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>[^\s]</string>
+					<key>name</key>
+					<string>invalid.illegal.type-parameter.erlang</string>
 				</dict>
 			</array>
 		</dict>


### PR DESCRIPTION
Line returns after a type name make make Sublime-Erlang highlight everything as an error until the next `.` token. Example of code:

``` erlang
-type attributes_data()
       :: [{'column', column()} | {'line', info_line()} | {'text', string()}
              | {'file', atom() | string()}]
        |  {line(), column()}.
```

Everything from `::` to `.` have a red background.
