### PR TITLE
Handle escape sequences like `\x{X...}` and `\xXY`

### DIFF
--- a/Erlang Expression.JSON-tmLanguage
+++ b/Erlang Expression.JSON-tmLanguage
@@ -30,7 +30,7 @@
                 "1": {"name": "punctuation.definition.escape.erlang"},
                 "3": {"name": "punctuation.definition.escape.erlang"}
               },
-              "match": "(\\\\)([bdefnrstv\\\\'\"]|(\\^)[@-_]|[0-7]{1,3})",
+              "match": "(\\\\)([bdefnrstv\\\\'\"]|(\\^)[@-_]|[0-7]{1,3}|x([0-9a-fA-F]{2}|\\{[0-9a-fA-F]+\\}))",
               "name": "constant.other.symbol.escape.erlang"
             },
             {
@@ -90,7 +90,7 @@
             "3": {"name": "punctuation.definition.escape.erlang"},
             "5": {"name": "punctuation.definition.escape.erlang"}
           },
-          "match": "(\\$)((\\\\)([bdefnrstv\\\\'\"]|(\\^)[@-_]|[0-7]{1,3}))",
+          "match": "(\\$)((\\\\)([bdefnrstv\\\\'\"]|(\\^)[@-_]|[0-7]{1,3}|x([0-9a-fA-F]{2}|\\{[0-9a-fA-F]+\\})))",
           "name": "constant.character.erlang"
         },
         {
@@ -991,7 +991,7 @@
             "1": {"name": "punctuation.definition.escape.erlang"},
             "3": {"name": "punctuation.definition.escape.erlang"}
           },
-          "match": "(\\\\)([bdefnrstv\\\\'\"]|(\\^)[@-_]|[0-7]{1,3})",
+          "match": "(\\\\)([bdefnrstv\\\\'\"]|(\\^)[@-_]|[0-7]{1,3}|x([0-9a-fA-F]{2}|\\{[0-9a-fA-F]+\\}))",
           "name": "constant.character.escape.erlang"
         },
         {

--- a/Erlang Expression.tmLanguage
+++ b/Erlang Expression.tmLanguage
@@ -64,7 +64,7 @@
 								</dict>
 							</dict>
 							<key>match</key>
-							<string>(\\)([bdefnrstv\\'"]|(\^)[@-_]|[0-7]{1,3})</string>
+							<string>(\\)([bdefnrstv\\'"]|(\^)[@-_]|[0-7]{1,3}|x([0-9a-fA-F]{2}|\{[0-9a-fA-F]+\}))</string>
 							<key>name</key>
 							<string>constant.other.symbol.escape.erlang</string>
 						</dict>
@@ -184,7 +184,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>(\$)((\\)([bdefnrstv\\'"]|(\^)[@-_]|[0-7]{1,3}))</string>
+					<string>(\$)((\\)([bdefnrstv\\'"]|(\^)[@-_]|[0-7]{1,3}|x([0-9a-fA-F]{2}|\{[0-9a-fA-F]+\})))</string>
 					<key>name</key>
 					<string>constant.character.erlang</string>
 				</dict>
@@ -2085,7 +2085,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>(\\)([bdefnrstv\\'"]|(\^)[@-_]|[0-7]{1,3})</string>
+					<string>(\\)([bdefnrstv\\'"]|(\^)[@-_]|[0-7]{1,3}|x([0-9a-fA-F]{2}|\{[0-9a-fA-F]+\}))</string>
 					<key>name</key>
 					<string>constant.character.escape.erlang</string>
 				</dict>


### PR DESCRIPTION
This fixes highlighting of hexadecimal escape sequences like in the following code:

``` erlang
    ?line {error,{1,erl_scan,Error},1} = erl_scan:string("\"qa\x{aaa}"),
```
