### PR TITLE
Support multiple clauses in -spec

### DIFF
--- a/Erlang.JSON-tmLanguage
+++ b/Erlang.JSON-tmLanguage
@@ -196,7 +196,7 @@
         "3": {"name": "punctuation.separator.module-function.erlang"},
         "4": {"name": "entity.name.function.erlang"}
       },
-      "end": "(?=;|\\.|\\)\\s*\\.)",
+      "end": "(?=\\.|\\)\\s*\\.)",
       "patterns": [
         {
           "name": "meta.type.function.parameters.erlang",

--- a/Erlang.tmLanguage
+++ b/Erlang.tmLanguage
@@ -1365,7 +1365,7 @@
 				</dict>
 			</dict>
 			<key>end</key>
-			<string>(?=;|\.|\)\s*\.)</string>
+			<string>(?=\.|\)\s*\.)</string>
 			<key>patterns</key>
 			<array>
 				<dict>


### PR DESCRIPTION
This fixes highlighting of the 'file' clause in the following snippet of code:

``` erlang
-spec set_attr('line', attributes(), fun((line()) -> line())) -> attributes();
              ('file', attributes(),
               fun(('undefined' | string()) -> 'undefined' | string()))
                  -> attributes().
```
