### PR TITLE
Improve build system

### DIFF
--- a/Erlang.sublime-build
+++ b/Erlang.sublime-build
@@ -1,5 +1,5 @@
 {
 	"cmd": ["erlc", "$file"],
-	"file_regex":"^([^:]+):([0-9]*):?(.*):?(.*)",
+	"file_regex":"^([^:]+)(?::([0-9]*))(?::(.*)): (.*)",
 	"selector": "source.erlang, source.yecc"
 }


### PR DESCRIPTION
These commits make Sublime-Erlang able to compile both `erl` and `yrl` files and improve support for the forthcoming column numbers in Erlang/OTP R16.

Supersedes #16.
